### PR TITLE
feat: 메인페이지 상태 업데이트시 자동 조회 및 일기 삭제 api 구현

### DIFF
--- a/src/api/deleteDiaryApi.ts
+++ b/src/api/deleteDiaryApi.ts
@@ -1,0 +1,8 @@
+import axiosInstance from "./axiosInstance"
+
+const deleteDiaryApi = async (diaryId: number) => {
+    const response = await axiosInstance.delete(`/api/diary/${diaryId}`)
+    return response.data
+}
+
+export default deleteDiaryApi

--- a/src/api/getMypage.ts
+++ b/src/api/getMypage.ts
@@ -4,8 +4,8 @@ interface MypageResponse {
   nickname: string
   email: string
   attendance: number
-  weeklyTotal: string
-  monthlyTotal: string
+  weeklyTotal: number
+  monthlyTotal: number
 }
 
 const getMypage = async (): Promise<MypageResponse> => {

--- a/src/api/getRanking.ts
+++ b/src/api/getRanking.ts
@@ -11,13 +11,13 @@ interface GetRankingParams {
 interface Ranker {
   name: string
   ranking: number
-  totalExerciseTime: string
+  totalExerciseTime: number
 }
 
 interface RankingResponse {
   myRanking: number
   myNickname: string
-  myTime: string
+  myTime: number
   slice: {
     content: Ranker[]
     pageable: {

--- a/src/api/getRanking.ts
+++ b/src/api/getRanking.ts
@@ -17,7 +17,7 @@ interface Ranker {
 interface RankingResponse {
   myRanking: number
   myNickname: string
-  myTime: number
+  myExerciseTime: number
   slice: {
     content: Ranker[]
     pageable: {

--- a/src/components/DiaryCreate.tsx
+++ b/src/components/DiaryCreate.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import { useState } from 'react'
-import { useMutation } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import axiosInstance from '../api/axiosInstance'
 import Modal from './Modal'
 
@@ -22,6 +22,8 @@ const postDiary = async (memo: string) => {
 }
 
 const DiaryCreate = () => {
+  const queryClient = useQueryClient()
+
   const [newDiary, setNewDiary] = useState('')
   const [isModalOpen, setIsModalOpen] = useState(false)
 
@@ -29,6 +31,7 @@ const DiaryCreate = () => {
     mutationFn: postDiary,
     onSuccess: () => {
       setNewDiary('')
+      queryClient.invalidateQueries({ queryKey: ['main'] })
     },
   })
 

--- a/src/components/ExerciseList.tsx
+++ b/src/components/ExerciseList.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import { useEffect, useRef, useState } from 'react'
-import { useMutation } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import Modal from './Modal'
 import postExercise from '../api/postExercise'
 import postStartExercise from '../api/postStartExercise'
@@ -25,6 +25,7 @@ const ExerciseList: React.FC<ExerciseListProps> = ({
   setTotalTime,
   setExerciseList,
 }) => {
+  const queryClient = useQueryClient()
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [exerciseNew, setExerciseNew] = useState('')
   const [activeMenuId, setActiveMenuId] = useState<number | null>(null)
@@ -50,6 +51,9 @@ const ExerciseList: React.FC<ExerciseListProps> = ({
 
   const addExercise = useMutation({
     mutationFn: postExercise,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['main'] })
+    }
   })
 
   const startExercise = useMutation({
@@ -58,6 +62,9 @@ const ExerciseList: React.FC<ExerciseListProps> = ({
 
   const deleteExercise = useMutation({
     mutationFn: deleteExerciseApi,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['main'] })
+    }
   })
 
   const handleDeleteClick = (exerciseId: number, event: React.MouseEvent) => {

--- a/src/components/Timer.tsx
+++ b/src/components/Timer.tsx
@@ -12,6 +12,14 @@ interface TimerProps {
   activeExerciseId?: number
 }
 
+export const formatTime = (runningTime: number) => {
+  if (Number.isNaN(runningTime)) return '00:00:00'
+  const hours = Math.floor((runningTime / 3600000) % 24)
+  const minutes = Math.floor((runningTime / 60000) % 60)
+  const seconds = Math.floor((runningTime / 1000) % 60)
+  return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`
+}
+
 const Timer: React.FC<TimerProps> = ({
   totalTime,
   setExerciseList,
@@ -74,14 +82,6 @@ const Timer: React.FC<TimerProps> = ({
     if (activeExerciseId) {
       stopExercise.mutate(activeExerciseId)
     }
-  }
-
-  const formatTime = (runningTime: number) => {
-    if (Number.isNaN(runningTime)) return '00:00:00'
-    const hours = Math.floor((runningTime / 3600000) % 24)
-    const minutes = Math.floor((runningTime / 60000) % 60)
-    const seconds = Math.floor((runningTime / 1000) % 60)
-    return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`
   }
 
   return (

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -21,12 +21,8 @@ const Main = () => {
   const formattedDate = DateTime.fromJSDate(selectedDate).toFormat('yyyyMMdd')
 
   const fetchExercise = useCallback(async () => {
-    const accessToken = localStorage.getItem('authToken')
 
     const response = await axiosInstance.get('/api', {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
       params: {
         date: formattedDate,
       },

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -42,7 +42,7 @@ const Main = () => {
     if (data) {
       const fetchedTotalTime = data?.totalTime || 0
       const fetchedExerciseList = data?.exerciseList || []
-      const fetchedDiary = data?.diaries || []
+      const fetchedDiary = data?.diaries.content || []
 
       setTotalTime(Number(fetchedTotalTime))
       setExerciseList(fetchedExerciseList)

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -5,7 +5,7 @@ import Personal from '../assets/personal.png'
 import getMypage from '../api/getMypage'
 import Loading from '../components/Loading'
 import Error from '../components/Error'
-import { formatDuration } from './Ranking'
+import { formatTime } from '../components/Timer'
 
 const MyPage = () => {
   const { data, isLoading, isError } = useQuery({
@@ -44,11 +44,11 @@ const MyPage = () => {
         </StaticTitleContainer>
         <MonthlyStatic>
           <MonthlyTitle>월별 통계</MonthlyTitle>
-          <MonthlyTime>{formatDuration(data?.monthlyTotal ?? '')}</MonthlyTime>
+          <MonthlyTime>{formatTime(data?.monthlyTotal ?? 0)}</MonthlyTime>
         </MonthlyStatic>
         <WeeklyStatic>
           <WeeklyTitle>주간 통계</WeeklyTitle>
-          <WeeklyTime>{formatDuration(data?.weeklyTotal ?? '')}</WeeklyTime>
+          <WeeklyTime>{formatTime(data?.weeklyTotal ?? 0)}</WeeklyTime>
         </WeeklyStatic>
       </StaticWrapper>
     </MypageWrapper>

--- a/src/pages/Ranking.tsx
+++ b/src/pages/Ranking.tsx
@@ -11,14 +11,6 @@ import Loading from '../components/Loading'
 import Error from '../components/Error'
 import { formatTime } from '../components/Timer'
 
-// export const formatDuration = (isoDuration: string) => {
-//   const duration = Duration.fromISO(isoDuration)
-//   const hours = String(duration.hours).padStart(2, '0')
-//   const minutes = String(duration.minutes).padStart(2, '0')
-//   const seconds = String(duration.seconds).padStart(2, '0')
-//   return `${hours}:${minutes}:${seconds}`
-// }
-
 const Ranking = () => {
   const { groupId } = useParams()
   const [selectedDate, setSelectedDate] = useState(new Date())
@@ -79,7 +71,7 @@ const Ranking = () => {
               {rankData.myRanking}
             </MyRankerCount>
             <RankerName>{rankData.myNickname}</RankerName>
-            <RankerTime>{formatTime(rankData.myTime)}</RankerTime>
+            <RankerTime>{formatTime(rankData.myExerciseTime)}</RankerTime>
           </MyRankElement>
         )}
       </MyRank>

--- a/src/pages/Ranking.tsx
+++ b/src/pages/Ranking.tsx
@@ -17,7 +17,7 @@ const Ranking = () => {
   const formattedDate = DateTime.fromJSDate(selectedDate).toFormat('yyyyMMdd')
 
   const { data, isLoading, isError } = useQuery({
-    queryKey: ['ranking', groupId],
+    queryKey: ['ranking', groupId, formattedDate],
     queryFn: () =>
       getRanking({
         groupId: groupId || '',

--- a/src/pages/Ranking.tsx
+++ b/src/pages/Ranking.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import { useEffect, useState } from 'react'
-import { DateTime, Duration } from 'luxon'
+import { DateTime } from 'luxon'
 import { useParams } from 'react-router'
 import { Link } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
@@ -9,14 +9,15 @@ import chatbubble from '../assets/chatbubble.svg'
 import getRanking from '../api/getRanking'
 import Loading from '../components/Loading'
 import Error from '../components/Error'
+import { formatTime } from '../components/Timer'
 
-export const formatDuration = (isoDuration: string) => {
-  const duration = Duration.fromISO(isoDuration)
-  const hours = String(duration.hours).padStart(2, '0')
-  const minutes = String(duration.minutes).padStart(2, '0')
-  const seconds = String(duration.seconds).padStart(2, '0')
-  return `${hours}:${minutes}:${seconds}`
-}
+// export const formatDuration = (isoDuration: string) => {
+//   const duration = Duration.fromISO(isoDuration)
+//   const hours = String(duration.hours).padStart(2, '0')
+//   const minutes = String(duration.minutes).padStart(2, '0')
+//   const seconds = String(duration.seconds).padStart(2, '0')
+//   return `${hours}:${minutes}:${seconds}`
+// }
 
 const Ranking = () => {
   const { groupId } = useParams()
@@ -66,9 +67,7 @@ const Ranking = () => {
             <RankElement key={ranker.name} index={index}>
               <RankerCount index={index}>{index + 1}</RankerCount>
               <RankerName>{ranker.name}</RankerName>
-              <RankerTime>
-                {formatDuration(ranker.totalExerciseTime)}
-              </RankerTime>
+              <RankerTime>{formatTime(ranker.totalExerciseTime)}</RankerTime>
             </RankElement>
           )) || <Error name="랭크" />}
         </EntireRank>
@@ -80,7 +79,7 @@ const Ranking = () => {
               {rankData.myRanking}
             </MyRankerCount>
             <RankerName>{rankData.myNickname}</RankerName>
-            <RankerTime>{formatDuration(rankData.myTime)}</RankerTime>
+            <RankerTime>{formatTime(rankData.myTime)}</RankerTime>
           </MyRankElement>
         )}
       </MyRank>

--- a/src/pages/Ranking.tsx
+++ b/src/pages/Ranking.tsx
@@ -129,18 +129,16 @@ const RankContainer = styled.div`
 `
 
 const DateContainer = styled.div`
-  padding: 15px 0;
+  padding: 15px 20px;
   color: #4a4a4a;
 `
 
 const EntireRank = styled.div`
-  height: 470px;
+  height: 400px;
   overflow-y: auto;
 `
 
 const MyRank = styled.div`
-  border: 1px solid #b5c3e9;
-  border-radius: 10px;
   margin-top: 20px;
 `
 
@@ -148,6 +146,8 @@ const MyRankElement = styled.div<{ ranking: number }>`
   display: flex;
   font-size: 18px;
   padding: 10px 20px;
+  border: 1px solid #b5c3e9;
+  border-radius: 10px;
   background: ${(props) => {
     if (props.ranking === 1)
       return 'linear-gradient(90deg, #FFF 0%, #FFC329 100%)'


### PR DESCRIPTION
## To do
- 랭킹 페이지 날짜 별 조회 통신 구현
- 랭킹 및 마이페이지 시간 타입 밀리초로 변경 (랭킹 및 마이페이지 통신 완료)
- 메인페이지 운동 및 일기 상태 업데이트시 데이터 자동 조회 구현 (post, put, delete시 자동 get 구현)
- 메인페이지 일기 삭제 api 구현

## 이슈
X

## 종속성 추가
npm install usehooks-ts

## Close Issue
Close #27 #34
